### PR TITLE
feat(pypi): add homepage and bug tracker into pypi metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ keywords = ["jquants", "api", "client", "J-Quants"]
 packages = [
     { include = "jquantsapi" }
 ]
+homepage = "https://github.com/J-Quants/jquants-api-client-python"
 
-[project.urls]
-"Homepage" = "https://github.com/J-Quants/jquants-api-client-python"
+[tool.poetry.urls]
 "Bug Tracker" = "https://github.com/J-Quants/jquants-api-client-python/issues"
 
 [build-system]


### PR DESCRIPTION
## WHAT

add homepage and bug tracker into pypi metadata to show them in pypi page.

## WHY

would like to add navigation to this repository for users.
This PR closes https://github.com/J-Quants/jquants-api-client-python/issues/5

