### PR TITLE
get_price_range()で、複数の型を引数として受け取れることを明示する

### DIFF
--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -1,8 +1,7 @@
 import os
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Union
 
-from typing import Union
 import pandas as pd  # type: ignore
 import requests
 from dateutil import tz
@@ -10,6 +9,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
 DatetimeLike = Union[datetime, pd.Timestamp, str]
+
 
 class Client:
     """

--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -280,8 +280,8 @@ class Client:
 
     def get_price_range(
         self,
-        start_dt: datetime = datetime(2017, 1, 1, tzinfo=tz.gettz("Asia/Tokyo")),
-        end_dt: datetime = datetime.now(tz.gettz("Asia/Tokyo")),
+        start_dt: str | datetime | pd.Timestamp = "20170101",
+        end_dt: str | datetime | pd.Timestamp = datetime.now(),
     ) -> pd.DataFrame:
         """
         全銘柄の株価情報を日付範囲指定して取得

--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -2,12 +2,14 @@ import os
 from datetime import datetime
 from typing import Dict
 
+from typing import Union
 import pandas as pd  # type: ignore
 import requests
 from dateutil import tz
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
+DatetimeLike = Union[datetime, pd.Timestamp, str]
 
 class Client:
     """
@@ -280,8 +282,8 @@ class Client:
 
     def get_price_range(
         self,
-        start_dt: str | datetime | pd.Timestamp = "20170101",
-        end_dt: str | datetime | pd.Timestamp = datetime.now(),
+        start_dt: DatetimeLike = "20170101",
+        end_dt: DatetimeLike = datetime.now(),
     ) -> pd.DataFrame:
         """
         全銘柄の株価情報を日付範囲指定して取得

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+[mypy-pandas]
+ignore_missing_imports = True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,44 @@
+import os
+from datetime import datetime
+from unittest.mock import MagicMock, call
+
+import pandas as pd
+from dateutil import tz
+
 import jquantsapi
 
 
-def test_jquants_api_client():
-    cli = jquantsapi.Client(refresh_token="hello")
-    print("Hello world")
-    print(cli)
-    assert True
+def test_get_price_range():
+    """
+    get_price_range()を呼ぶ際、引数に様々な型が入っていても問題なく
+    get_prices_daily_quotes()に単一の年月日が渡される事を確認する。
+    """
+    # テストではHTTP通信を行わず、get_prices_daily_quotes()をモックすることで、
+    # 実際に通信が発生しないようにする。
+    mock = MagicMock(return_value=pd.DataFrame())
+    cli = jquantsapi.Client(refresh_token="dummy")
+    cli.get_prices_daily_quotes = mock  # get_prices_daily_quotes() をモックに置き換える
+    formats = {
+        # テストする期間はいつでも良いので、何かが起こりやすい閏日をテスト対象に含む
+        "str_8digits": ("20200227", "20200302"),
+        "str_split_by_hyphen": ("2020-02-27", "2020-03-02"),
+        "datetime_without_tz": (datetime(2020, 2, 27), datetime(2020, 3, 2)),
+        "datetime_with_tz": (
+            datetime(2020, 2, 27, tzinfo=tz.gettz("Asia/Tokyo")),
+            datetime(2020, 3, 2, tzinfo=tz.gettz("Asia/Tokyo")),
+        ),
+        "pd.Timestamp": (pd.Timestamp("2020-02-27"), pd.Timestamp("2020-03-02")),
+    }
+
+    for _fmt, (start, end) in formats.items():
+        cli.get_price_range(start, end)
+
+        # 呼び出しの履歴と、get_prices_daily_quotes()が呼ばれた際の年月日8桁の引数を比較
+        assert mock.mock_calls == [
+            call.get_prices_daily_quotes(date_yyyymmdd="20200227"),
+            call.get_prices_daily_quotes(date_yyyymmdd="20200228"),
+            call.get_prices_daily_quotes(date_yyyymmdd="20200229"),
+            call.get_prices_daily_quotes(date_yyyymmdd="20200301"),
+            call.get_prices_daily_quotes(date_yyyymmdd="20200302"),
+        ]
+        mock.reset_mock()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime
 from unittest.mock import MagicMock, call
 


### PR DESCRIPTION
## WHAT

`get_price_range()` の型ヒントで、`str` , `datetime` , `pd.Timestamp` を受け取ることを明示。
また、その際内部的に呼ばれる `get_prices_daily_quotes()` に想定通りの年月日が渡ることを確認するテストを追加。

このPRがマージできそうであれば、他のメソッドも同様に型ヒントを広く指定できる可能性がある。

## WHY

`pd.date_range()` が `str` , `datetime` , `pd.Timestamp` を引数に取ることができ、 その制約をそのまま`get_price_range()` の型ヒントとして明示することで、そのメソッドを呼ぶ際に不要な型の変換を回避できるようにするため。

その他詳細は #13 に書いた。
closes #13

## TODO

- [x] テストではなく、パッケージとして実際に動作確認する
- [x] `Union` による型ヒントの書き換えで、Python 3.7+をサポート対象にする