### PR TITLE
feat: reuse requests.Session with concurrent requesting

### DIFF
--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pandas as pd  # type: ignore
 import requests
@@ -25,7 +25,7 @@ class Client:
         self.refresh_token = refresh_token
         self._id_token = ""
         self._id_token_expire = pd.Timestamp.utcnow()
-        self._session = None
+        self._session: Optional[requests.Session] = None
 
     def _base_headers(self) -> dict:
         """

--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -298,7 +298,7 @@ class Client:
             end_dt: 取得終了日
 
         Returns:
-            pd.DataFrame: 株価情報
+            pd.DataFrame: 株価情報 (Code, Date列でソートされています)
         """
         buff = []
         dates = pd.date_range(start_dt, end_dt, freq="D")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ def test_get_price_range():
     """
     # テストではHTTP通信を行わず、get_prices_daily_quotes()をモックすることで、
     # 実際に通信が発生しないようにする。
-    mock = MagicMock(return_value=pd.DataFrame())
+    mock = MagicMock(return_value=pd.DataFrame(columns=["Code", "Date"]))
     cli = jquantsapi.Client(refresh_token="dummy")
     cli.get_prices_daily_quotes = mock  # get_prices_daily_quotes() をモックに置き換える
     formats = {


### PR DESCRIPTION
## WHAT
- データ取得時にHTTPコネクションを再使用するようにしました
- get_price_range でリクエストを並行処理するようにしました



 
before
```
In [4]: %%time
   ...: df2 = cli.get_price_range(datetime(2022, 8, 1, tzinfo=tz.gettz("Asia/Tokyo")), datetime(2022,
   ...:  8, 9, tzinfo=tz.gettz("Asia/Tokyo")))
   ...: 
   ...: 
CPU times: user 788 ms, sys: 188 ms, total: 977 ms
Wall time: 1min 21s
```

after
```
In [2]: %%time
   ...: df2 = cli.get_price_range(datetime(2022, 8, 1, tzinfo=tz.gettz("Asia/Tokyo")), datetime(2
   ...: 022, 8, 9, tzinfo=tz.gettz("Asia/Tokyo")))
   ...: 
   ...: 
CPU times: user 711 ms, sys: 138 ms, total: 849 ms
Wall time: 22.8 s
```

## WHY
closes https://github.com/J-Quants/jquants-api-client-python/issues/14