### PR TITLE
fix: increase the connection pool size

### DIFF
--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -39,9 +39,9 @@ class Client:
         return headers
 
     def _request_session(
-        self,
-        status_forcelist: Optional[List[int]] = None,
-        method_whitelist: Optional[List[str]] = None,
+            self,
+            status_forcelist: Optional[List[int]] = None,
+            method_whitelist: Optional[List[str]] = None,
     ):
         """
         requests の session 取得
@@ -65,7 +65,11 @@ class Client:
                 status_forcelist=status_forcelist,
                 method_whitelist=method_whitelist,
             )
-            adapter = HTTPAdapter(max_retries=retry_strategy)
+            adapter = HTTPAdapter(
+                pool_connections=self.MAX_WORKERS,
+                pool_maxsize=self.MAX_WORKERS,
+                max_retries=retry_strategy,
+            )
             self._session = requests.Session()
             self._session.mount("https://", adapter)
 
@@ -93,7 +97,7 @@ class Client:
         return ret
 
     def _post(
-        self, url: str, payload: dict = None, headers: dict = None
+            self, url: str, payload: dict = None, headers: dict = None
     ) -> requests.Response:
         """
         requests の get 用ラッパー
@@ -231,11 +235,11 @@ class Client:
         return df_list
 
     def get_prices_daily_quotes(
-        self,
-        code: str = "",
-        from_yyyymmdd: str = "",
-        to_yyyymmdd: str = "",
-        date_yyyymmdd: str = "",
+            self,
+            code: str = "",
+            from_yyyymmdd: str = "",
+            to_yyyymmdd: str = "",
+            date_yyyymmdd: str = "",
     ) -> pd.DataFrame:
         """
         株価情報を取得
@@ -286,9 +290,9 @@ class Client:
         return df[cols]
 
     def get_price_range(
-        self,
-        start_dt: DatetimeLike = "20170101",
-        end_dt: DatetimeLike = datetime.now(),
+            self,
+            start_dt: DatetimeLike = "20170101",
+            end_dt: DatetimeLike = datetime.now(),
     ) -> pd.DataFrame:
         """
         全銘柄の株価情報を日付範囲指定して取得
@@ -316,7 +320,7 @@ class Client:
         return pd.concat(buff).sort_values(["Code", "Date"])
 
     def get_fins_statements(
-        self, code: str = "", date_yyyymmdd: str = ""
+            self, code: str = "", date_yyyymmdd: str = ""
     ) -> pd.DataFrame:
         """
         財務情報取得
@@ -428,10 +432,10 @@ class Client:
         return df[cols]
 
     def get_statements_range(
-        self,
-        start_dt: datetime = datetime(2017, 1, 1, tzinfo=tz.gettz("Asia/Tokyo")),
-        end_dt: datetime = datetime.now(tz.gettz("Asia/Tokyo")),
-        cache_dir: str = "",
+            self,
+            start_dt: datetime = datetime(2017, 1, 1, tzinfo=tz.gettz("Asia/Tokyo")),
+            end_dt: datetime = datetime.now(tz.gettz("Asia/Tokyo")),
+            cache_dir: str = "",
     ) -> pd.DataFrame:
         """
         財務情報を日付範囲指定して取得
@@ -451,7 +455,7 @@ class Client:
             # fetch data via API or cache file
             cache_file = f"fins_statements_{s.strftime('%Y%m%d')}.csv.gz"
             if (cache_dir != "") and os.path.isfile(
-                f"{cache_dir}/{s.strftime('%Y')}/{cache_file}"
+                    f"{cache_dir}/{s.strftime('%Y')}/{cache_file}"
             ):
                 df = pd.read_csv(f"{cache_dir}/{s.strftime('%Y')}/{cache_file}")
             else:

--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -66,8 +66,8 @@ class Client:
                 method_whitelist=method_whitelist,
             )
             adapter = HTTPAdapter(
-                pool_connections=self.MAX_WORKERS,
-                pool_maxsize=self.MAX_WORKERS,
+                pool_connections=self.MAX_WORKERS + 10,
+                pool_maxsize=self.MAX_WORKERS + 10,
                 max_retries=retry_strategy,
             )
             self._session = requests.Session()

--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -39,9 +39,9 @@ class Client:
         return headers
 
     def _request_session(
-            self,
-            status_forcelist: Optional[List[int]] = None,
-            method_whitelist: Optional[List[str]] = None,
+        self,
+        status_forcelist: Optional[List[int]] = None,
+        method_whitelist: Optional[List[str]] = None,
     ):
         """
         requests の session 取得
@@ -66,6 +66,7 @@ class Client:
                 method_whitelist=method_whitelist,
             )
             adapter = HTTPAdapter(
+                # 安全のため並列スレッド数に更に10追加しておく
                 pool_connections=self.MAX_WORKERS + 10,
                 pool_maxsize=self.MAX_WORKERS + 10,
                 max_retries=retry_strategy,
@@ -97,7 +98,7 @@ class Client:
         return ret
 
     def _post(
-            self, url: str, payload: dict = None, headers: dict = None
+        self, url: str, payload: dict = None, headers: dict = None
     ) -> requests.Response:
         """
         requests の get 用ラッパー
@@ -235,11 +236,11 @@ class Client:
         return df_list
 
     def get_prices_daily_quotes(
-            self,
-            code: str = "",
-            from_yyyymmdd: str = "",
-            to_yyyymmdd: str = "",
-            date_yyyymmdd: str = "",
+        self,
+        code: str = "",
+        from_yyyymmdd: str = "",
+        to_yyyymmdd: str = "",
+        date_yyyymmdd: str = "",
     ) -> pd.DataFrame:
         """
         株価情報を取得
@@ -290,9 +291,9 @@ class Client:
         return df[cols]
 
     def get_price_range(
-            self,
-            start_dt: DatetimeLike = "20170101",
-            end_dt: DatetimeLike = datetime.now(),
+        self,
+        start_dt: DatetimeLike = "20170101",
+        end_dt: DatetimeLike = datetime.now(),
     ) -> pd.DataFrame:
         """
         全銘柄の株価情報を日付範囲指定して取得
@@ -320,7 +321,7 @@ class Client:
         return pd.concat(buff).sort_values(["Code", "Date"])
 
     def get_fins_statements(
-            self, code: str = "", date_yyyymmdd: str = ""
+        self, code: str = "", date_yyyymmdd: str = ""
     ) -> pd.DataFrame:
         """
         財務情報取得
@@ -432,10 +433,10 @@ class Client:
         return df[cols]
 
     def get_statements_range(
-            self,
-            start_dt: datetime = datetime(2017, 1, 1, tzinfo=tz.gettz("Asia/Tokyo")),
-            end_dt: datetime = datetime.now(tz.gettz("Asia/Tokyo")),
-            cache_dir: str = "",
+        self,
+        start_dt: datetime = datetime(2017, 1, 1, tzinfo=tz.gettz("Asia/Tokyo")),
+        end_dt: datetime = datetime.now(tz.gettz("Asia/Tokyo")),
+        cache_dir: str = "",
     ) -> pd.DataFrame:
         """
         財務情報を日付範囲指定して取得
@@ -455,7 +456,7 @@ class Client:
             # fetch data via API or cache file
             cache_file = f"fins_statements_{s.strftime('%Y%m%d')}.csv.gz"
             if (cache_dir != "") and os.path.isfile(
-                    f"{cache_dir}/{s.strftime('%Y')}/{cache_file}"
+                f"{cache_dir}/{s.strftime('%Y')}/{cache_file}"
             ):
                 df = pd.read_csv(f"{cache_dir}/{s.strftime('%Y')}/{cache_file}")
             else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,6 @@ def test_get_price_range():
     # 実際に通信が発生しないようにする。
     mock = MagicMock(return_value=pd.DataFrame(columns=["Code", "Date"]))
     cli = jquantsapi.Client(refresh_token="dummy")
-
     cli.get_prices_daily_quotes = mock  # get_prices_daily_quotes() をモックに置き換える
     formats = {
         # テストする期間はいつでも良いので、何かが起こりやすい閏日をテスト対象に含む
@@ -42,7 +41,3 @@ def test_get_price_range():
             call.get_prices_daily_quotes(date_yyyymmdd="20200302"),
         ]
         mock.reset_mock()
-
-
-def test_client():
-    assert False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,7 @@ def test_get_price_range():
     # 実際に通信が発生しないようにする。
     mock = MagicMock(return_value=pd.DataFrame(columns=["Code", "Date"]))
     cli = jquantsapi.Client(refresh_token="dummy")
+
     cli.get_prices_daily_quotes = mock  # get_prices_daily_quotes() をモックに置き換える
     formats = {
         # テストする期間はいつでも良いので、何かが起こりやすい閏日をテスト対象に含む
@@ -41,3 +42,7 @@ def test_get_price_range():
             call.get_prices_daily_quotes(date_yyyymmdd="20200302"),
         ]
         mock.reset_mock()
+
+
+def test_client():
+    assert False


### PR DESCRIPTION
## WHAT
- jquants-api-clientの使用するコネクションプールの最大数、キャッシュ数を並列処理スレッド数よりも大きい値にする
<!-- このプルリクエストで変更された内容 -->

## WHY
- デフォルトのコネクションプール数は10なので、それ以上の値のMAX_WORKERSを使用すると
`WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: api.jpx-jquants.com`
警告が出てしまう。
それだけでエラーになるわけではないけれど、コネクションが再利用されないのは悲しいのでこの値をあらかじめ変えておく
<!-- このプルリクエストを作成しようと思った理由 -->
