### PR TITLE
client.py comment fix

### DIFF
--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -622,7 +622,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
             pagination_key: ページングキー
 
@@ -648,7 +648,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
         Returns: pd.DataFrame: the morning session's OHLC data
         """
@@ -761,7 +761,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
             from_yyyymmdd: starting point of data period (e.g. 20210901 or 2021-09-01)
             to_yyyymmdd: end point of data period (e.g. 20210907 or 2021-09-07)
@@ -799,7 +799,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
             from_yyyymmdd: starting point of data period (e.g. 20210901 or 2021-09-01)
             to_yyyymmdd: end point of data period (e.g. 20210907 or 2021-09-07)
@@ -992,7 +992,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
             from_yyyymmdd: starting point of data period (e.g. 20210901 or 2021-09-01)
             to_yyyymmdd: end point of data period (e.g. 20210907 or 2021-09-07)
@@ -1030,7 +1030,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
             from_yyyymmdd: starting point of data period (e.g. 20210901 or 2021-09-01)
             to_yyyymmdd: end point of data period (e.g. 20210907 or 2021-09-07)
@@ -1441,7 +1441,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
             from_yyyymmdd: starting point of data period (e.g. 20210901 or 2021-09-01)
             to_yyyymmdd: end point of data period (e.g. 20210907 or 2021-09-07)
@@ -1479,7 +1479,7 @@ class Client:
 
         Args:
             code: issue code (e.g. 27800 or 2780)
-                If a 4-digit issue code is specified, only the data of common stock will be obtained
+                If a 4-character issue code is specified, only the data of common stock will be obtained
                 for the issue on which both common and preferred stocks are listed.
             from_yyyymmdd: starting point of data period (e.g. 20210901 or 2021-09-01)
             to_yyyymmdd: end point of data period (e.g. 20210907 or 2021-09-07)


### PR DESCRIPTION
## WHAT
<!-- このプルリクエストで変更された内容 -->
銘柄コードに関するコメントの4-digitを4-characterに変更

## WHY
<!-- このプルリクエストを作成しようと思った理由 -->
銘柄コードの英数字化によって、銘柄コードが4桁の数字から4文字の文字に変更となるため
