### PR TITLE
listed/infoに英語の会社名称列の漏れがあったので追加

### DIFF
--- a/jquantsapi/constants.py
+++ b/jquantsapi/constants.py
@@ -4,6 +4,7 @@ LISTED_INFO_COLUMNS = [
     "Date",
     "Code",
     "CompanyName",
+    "CompanyNameEnglish",
     "Sector17Code",
     "Sector17CodeName",
     "Sector33Code",
@@ -17,6 +18,7 @@ LISTED_INFO_STANDARD_PREMIUM_COLUMNS = [
     "Date",
     "Code",
     "CompanyName",
+    "CompanyNameEnglish",
     "Sector17Code",
     "Sector17CodeName",
     "Sector33Code",
@@ -30,7 +32,8 @@ LISTED_INFO_STANDARD_PREMIUM_COLUMNS = [
 
 # ref. ja https://jpx.gitbook.io/j-quants-ja/api-reference/listed_info/sector17code
 # ref. en https://jpx.gitbook.io/j-quants-en/api-reference/listed_info/sector17code
-SECTOR_17_COLUMNS = ["Sector17Code", "Sector17CodeName", "Sector17CodeNameEnglish"]
+SECTOR_17_COLUMNS = ["Sector17Code",
+                     "Sector17CodeName", "Sector17CodeNameEnglish"]
 SECTOR_17_DATA = [
     ("1", "食品", "FOODS"),
     ("2", "エネルギー資源", "ENERGY RESOURCES"),

--- a/jquantsapi/constants.py
+++ b/jquantsapi/constants.py
@@ -32,8 +32,7 @@ LISTED_INFO_STANDARD_PREMIUM_COLUMNS = [
 
 # ref. ja https://jpx.gitbook.io/j-quants-ja/api-reference/listed_info/sector17code
 # ref. en https://jpx.gitbook.io/j-quants-en/api-reference/listed_info/sector17code
-SECTOR_17_COLUMNS = ["Sector17Code",
-                     "Sector17CodeName", "Sector17CodeNameEnglish"]
+SECTOR_17_COLUMNS = ["Sector17Code", "Sector17CodeName", "Sector17CodeNameEnglish"]
 SECTOR_17_DATA = [
     ("1", "食品", "FOODS"),
     ("2", "エネルギー資源", "ENERGY RESOURCES"),


### PR DESCRIPTION
## WHAT
<!-- このプルリクエストで変更された内容 -->
Dataframeにする際のカラム選択においてCompanyNameEnglishも含むように追記

## WHY
<!-- このプルリクエストを作成しようと思った理由 -->
listed/infoのメソッドにおいて、企業の英語名称の列選択が漏れていたため