### PR TITLE
add AfternoonTurnoverValue column

### DIFF
--- a/jquantsapi/constants.py
+++ b/jquantsapi/constants.py
@@ -158,6 +158,7 @@ PRICES_DAILY_QUOTES_PREMIUM_COLUMNS = [
     "AfternoonUpperLimit",
     "AfternoonLowerLimit",
     "AfternoonVolume",
+    "AfternoonTurnoverValue",
     "AfternoonAdjustmentOpen",
     "AfternoonAdjustmentHigh",
     "AfternoonAdjustmentLow",


### PR DESCRIPTION
## WHAT
get_prices_daily_quotesで返却されるDataFrameに"AfternoonTurnoverValue"カラムを追加しました。
（これはプレミアムプランの時のみ影響）

## WHY
get_prices_daily_quotesで返却されるDataFrameに"AfternoonTurnoverValue"が不足していました