### PR TITLE
fix: Fix a way to install poetry-dynamic-versioning in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install poetry
         run: |
           pipx install poetry
-          pipx install poetry-dynamic-versioning
+          poetry self add "poetry-dynamic-versioning[plugin]"
       - name: Setup python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## WHAT
- fix a way to install poetry-dynamic-versioning in publish.yml

## WHY
- failing publishing to pypi via github action due to dynamic versioning
