### PR TITLE
fix help comment of `_post` method

### DIFF
--- a/jquantsapi/client.py
+++ b/jquantsapi/client.py
@@ -243,7 +243,7 @@ class Client:
         headers: Optional[dict] = None,
     ) -> requests.Response:
         """
-        requests の get 用ラッパー
+        requests の post 用ラッパー
 
         タイムアウトを設定
 


### PR DESCRIPTION
## WHAT
Fixed incorrect comment in the `_post` method.

## WHY
I was just reading codes and found it.