### PR TITLE
日々公表信用取引残高APIの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ J-Quants API の各 API エンドポイントに対応しています。
 - get_markets_short_selling
 - get_indices
 - get_short_selling_positions
+- get_markets_daily_margin_interest
 
 ------------------ Premium plan or higher is required ------------------
 
@@ -121,6 +122,7 @@ J-Quants API の各 API エンドポイントに対応しています。
 - get_short_selling_range
 - get_index_option_range
 - get_short_selling_positions_range
+- get_daily_margin_interest_range
 
 ------------------ Premium plan or higher is required ------------------
 

--- a/jquantsapi/constants.py
+++ b/jquantsapi/constants.py
@@ -607,3 +607,33 @@ SHORT_SELLING_POSITIONS_COLUMNS = [
     "ShortPositionsInPreviousReportingRatio",
     "Notes",
 ]
+
+# ref. ja https://jpx.gitbook.io/j-quants-ja/api-reference/daily_margin_interest
+# ref. en https://jpx.gitbook.io/j-quants-en/api-reference/daily_margin_interest
+DAILY_MARGIN_INTEREST_COLUMNS = [
+    "PublishedDate",
+    "Code",
+    "ApplicationDate",
+    "PublishReason.Restricted",
+    "PublishReason.DailyPublication",
+    "PublishReason.Monitoring",
+    "PublishReason.RestrictedByJSF",
+    "PublishReason.PrecautionByJSF",
+    "PublishReason.UnclearOrSecOnAlert",
+    "ShortMarginOutstanding",
+    "DailyChangeShortMarginOutstanding",
+    "ShortMarginOutstandingListedShareRatio",
+    "LongMarginOutstanding",
+    "DailyChangeLongMarginOutstanding",
+    "LongMarginOutstandingListedShareRatio",
+    "ShortLongRatio",
+    "ShortNegotiableMarginOutstanding",
+    "DailyChangeShortNegotiableMarginOutstanding",
+    "ShortStandardizedMarginOutstanding",
+    "DailyChangeShortStandardizedMarginOutstanding",
+    "LongNegotiableMarginOutstanding",
+    "DailyChangeLongNegotiableMarginOutstanding",
+    "LongStandardizedMarginOutstanding",
+    "DailyChangeLongStandardizedMarginOutstanding",
+    "TSEMarginBorrowingAndLendingRegulationClassification",
+]


### PR DESCRIPTION
## WHAT
- 日々公表信用取引残高APIの追加

## WHY
- 日々公表信用取引残高APIリリースに伴う機能追加
